### PR TITLE
Use built-in Yumrepo resource type instead of Exec

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -9,15 +9,10 @@
 define rhsm::repo (
 ) {
 
-  if $rhsm::proxy_hostname {
-    $proxycli = "--proxy=http://${rhsm::proxy_hostname}:${rhsm::proxy_port} --proxyuser=${rhsm::proxy_user} --proxypass=${rhsm::proxy_password}"
+  yumrepo { $title:
+    enable  => true,
+    require => Package['subscription-manager'],
+    target  => '/etc/yum.repos.d/redhat.repo',
   }
 
-  $command = "/usr/sbin/subscription-manager repos --enable=${title} ${proxycli}"
-
-  exec { "RHSM::repo register ${title}":
-    command => $command,
-    unless  => "/usr/sbin/subscription-manager repos --list-enabled | /bin/grep ${title}",
-    require => [ Exec['RHNSM-register'], Package['subscription-manager'] ] ,
-  }
 }


### PR DESCRIPTION
Puppet has a built-in resource type to manage YUM repository. The subscription-manager generates all the Red Hat repo configuration in a single file. Using the Puppet resource type 'target' parameter allows to manage this generated list with the resource type.