### PR TITLE
Remove CentOS from target OS list and added RHEL 5.7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,16 +15,9 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "5.0",
-        "6.0",
-        "7.0"
-      ]
-    },
-    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+        "5.7",
         "6",
         "7"
       ]


### PR DESCRIPTION
In response to #16 
Would be nice if Puppet allowed us to set lower/upper version boundaries in supported OS.
I added RHEL 5.7 (not listing all the way to 5.11) to flag the module for any user who might still run RHEL 5 and looks for help managing RHSM. But in reality subscription-manager is available in RHEL 5.7 and above, RHEL 6 got it in 6.1.
https://access.redhat.com/solutions/253273