### PR TITLE
Separated Registration and Subscription tasks

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class rhsm (
     path    => '/usr/sbin',
     require => Package['subscription-manager'],
   }
-  
+
   exec { 'RHNSM-subscribe':
     command => $command,
     onlyif  => 'subscription-manager list | grep "Not Subscribed\|Unknown"',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,9 +68,9 @@ class rhsm (
   }
 
   if $pool == undef {
-    $command = "/usr/sbin/subscription-manager register --name='${::fqdn}'  --username='${rh_user}' --password='${rh_password}' --auto-attach ${proxycli}"
+    $command = "subscription-manager attach --auto ${proxycli}"
   } else {
-    $command = "/usr/sbin/subscription-manager register --name='${::fqdn}'  --username='${rh_user}' --password='${rh_password}' ${proxycli} && /usr/sbin/subscription-manager attach --pool=${pool}"
+    $command = "subscription-manager attach --pool=${pool} ${proxycli}"
   }
 
   package { 'subscription-manager':
@@ -89,9 +89,17 @@ class rhsm (
   }
 
   exec { 'RHNSM-register':
-    command => $command,
-    onlyif  => '/usr/sbin/subscription-manager list | grep "Not Subscribed\|Unknown"',
+    command => "subscription-manager register --name='${::fqdn}' --username='${rh_user}' --password='${rh_password}' ${proxycli}",
+    onlyif  => 'subscription-manager identity | grep "not yet registered"',
+    path    => '/usr/sbin',
     require => Package['subscription-manager'],
+  }
+  
+  exec { 'RHNSM-subscribe':
+    command => $command,
+    onlyif  => 'subscription-manager list | grep "Not Subscribed\|Unknown"',
+    path    => '/usr/sbin',
+    require => Exec['RHNSM-register'],
   }
 
   if $repo_extras {


### PR DESCRIPTION
To be able to change an expired subscription (for example) on an already registered system, the two tasks needed to be separated.
While at it, '/usr/sbin' was added to the path to shorten the command executed and onlyif conditions in the Exec resources.

There might be an edge case where a registered system with an active subscription gets a new poolid value assigned by Puppet but that won't be updated on the node. That was already a problem the module couldn't handle before and should probably the next step now that subscription is separated from registration.