### PR TITLE
Add 'Expired' in grep to trigger subscription

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,7 +127,7 @@ class rhsm (
 
   exec { 'RHNSM-subscribe':
     command => $command,
-    onlyif  => 'subscription-manager list 2>&1 | grep "Not Subscribed\|Unknown"',
+    onlyif  => 'subscription-manager list 2>&1 | grep "Expired\|Not Subscribed\|Unknown"',
     path    => '/bin:/usr/bin:/usr/sbin',
     require => Exec['RHNSM-register'],
   }


### PR DESCRIPTION
Added 'Expired' to cover cases where a valid subscription expired and the module should trigger a new subscription on nodes not meant to use auto-attach.