### PR TITLE
Added confine rule on Fact

### DIFF
--- a/lib/facter/rhsm_repos.rb
+++ b/lib/facter/rhsm_repos.rb
@@ -1,4 +1,5 @@
 Facter.add('rhsm_repos') do
+  confine :osfamily => :RedHat
   setcode do
     repos = Array.[]
     repo_list = Facter::Core::Execution.exec("yum repolist | awk '/Red Hat/ {print $1}'")

--- a/lib/facter/rhsm_repos.rb
+++ b/lib/facter/rhsm_repos.rb
@@ -1,5 +1,5 @@
 Facter.add('rhsm_repos') do
-  confine :osfamily => :RedHat
+  confine osfamily: :RedHat
   setcode do
     repos = Array.[]
     repo_list = Facter::Core::Execution.exec("yum repolist | awk '/Red Hat/ {print $1}'")


### PR DESCRIPTION
Without this, any other node than Red Hat (could be Windows) with this module in its node classification would have the Puppet Ruby runtime attempting to execute this Fact.