### PR TITLE
Change documentation syntax to YARD/Puppet Strings and update template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This module registers your systems with Redhat Subscription Management.
+This module registers your systems with RedHat Subscription Management.
 
 ## Setup
 
@@ -15,7 +15,8 @@ Just declare the module with parameters, or load the data from Hiera.
    rh_password => 'mypassword',
   }
 ```
-To attach the system to a specific pool (can be found on a registered system with 'subscription-manager list --available'):
+To attach the system to a specific pool (can be found on a registered system with `subscription-manager list --available`):
+
 ```puppet
   class { 'rhsm':
    rh_user     => 'myuser',
@@ -29,13 +30,15 @@ To attach the system to a specific pool (can be found on a registered system wit
   include rhsm
 ```
   Hierafile:
+
 ```yaml
-  rhsm::rh_user: myuser
-  rhsm::rh_password: mypassword
+rhsm::rh_user: myuser
+rhsm::rh_password: mypassword
 ```
 
 ### Proxy
 If the RedHat node must use a proxy to access the internet, you'll have to provide at least the hostname and TCP port.
+
 ```puppet
   class { 'rhsm':
    proxy_hostname => 'my.proxy.net',
@@ -44,9 +47,9 @@ If the RedHat node must use a proxy to access the internet, you'll have to provi
    rh_password    => 'mypassword',
   }
 ```
-You shouldn't specify the protocol, subscription-manager will use HTTP. For proxies with authentication, specify the 'proxy_user' and 'proxy_password' values.
+You shouldn't specify the protocol, subscription-manager will use HTTP. For proxies with authentication, specify the `proxy_user` and `proxy_password` values.
 
-The proxy settings will be used to register the system and as connection option for all the YUM repositories generated in /etc/yum.repos.d/redhat.repo
+The proxy settings will be used to register the system and as connection option for all the YUM repositories generated in `/etc/yum.repos.d/redhat.repo`
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,46 +1,38 @@
-# == Class: rhsm
+# rhsm
 #
-# Subscribe the node to the RHSM
-#
-# === Parameters
-#
-# Document parameters here.
-#
-# [*rh_user*]
-#   User for the Customer Portal
-# [*rh_password*]
-#   Password for the rh_user account
-# [*servername*]
-#   Servername, default is provided.
-# [*pool*]
-#   Attach system to a specific pool instead of auto attach to compatible subscriptions.
-# [*proxy_hostname*]
-#   Proxy hostname
-# [*proxy_port*]
-#   Proxy port
-# [*proxy_user*]
-#   Proxy user
-# [*proxy_password*]
-#   Proxy password
-# [*baseurl*]
-#   Base URL for rhsm, default provided.
-#
-# === Examples
-#
-# include rhsm
-#
-# Hierafile:
-# ---
-# rhsm::rh_user: myuser
-# rhsm::rh_password: mypassword
-#
-# === Authors
-#
-# Ger Apeldoorn <info@gerapeldoorn.nl>
-#
-# === Copyright
+# Subscribe the node to RHSM
 #
 # Copyright 2014 Ger Apeldoorn, unless otherwise noted.
+#
+# @summary Subscribe the node to RHSM
+#
+# @param rh_user [String] User for the Customer Portal.
+#   You need to specify either (rh_user and rh_password) or (org and activationkey)
+# @param rh_password [String] Password for the rh_user account
+# @param org [String] Organization to use
+# @param activationkey [String] Activationkey to use
+# @param servername [String] Servername, default provided
+#   Used directly in rhsm.conf template
+# @param pool [String] Attach system to a specific pool instead of auto attach to compatible subscriptions
+# @param proxy_hostname [String] Proxy hostname
+# @param proxy_port [String] Proxy port
+# @param proxy_user [String] Proxy user
+# @param proxy_password [String] Proxy password
+# @param baseurl [String] Base URL for rhsm, default provided
+# @param package_ensure [String] Whether to install subscription-manager
+# @param repo_extras [Boolean] Enable extras repository
+# @param repo_optional [Boolean] Enable optional repository
+#
+# @example
+#   include rhsm
+#
+# @example
+#   # Hierafile:
+#   ---
+#   rhsm::rh_user: myuser
+#   rhsm::rh_password: mypassword
+#
+# @author Ger Apeldoorn <info@gerapeldoorn.nl>
 #
 class rhsm (
   $rh_user        = undef,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,11 +1,15 @@
-# === Authors
+# rhsm::repo
 #
-# Ger Apeldoorn <info@gerapeldoorn.nl>
-#
-# === Copyright
+# Target file is /etc/yum.repos.d/redhat.repo
 #
 # Copyright 2014 Ger Apeldoorn, unless otherwise noted.
 #
+# @summary Manage additional RedHat repositories
+#
+# @author Ger Apeldoorn <info@gerapeldoorn.nl>
+#
+# @example
+#   ::rhsm::repo { "rhel-${::operatingsystemmajrelease}-server-extras-rpms": }
 define rhsm::repo (
 ) {
   yumrepo { $title:


### PR DESCRIPTION
Change documentation syntax to YARD/Puppet Strings and update rhsm template

Optimize README for puppet strings

Red Hat disabled the old Red Hat Network (RHN), so servername is changed from subscription.rhn.redhat.com to subscription.rhsm.redhat.com

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
