### PR TITLE
Change servername to subscription.rhsm.redhat.com

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class rhsm (
   $rh_password    = undef,
   $org            = undef,
   $activationkey  = undef,
-  $servername     = 'subscription.rhn.redhat.com',
+  $servername     = 'subscription.rhsm.redhat.com',
   $pool           = undef,
   $proxy_hostname = undef,
   $proxy_port     = undef,
@@ -118,29 +118,29 @@ class rhsm (
     content => template('rhsm/rhsm.conf.erb'),
   }
 
-  exec { 'RHNSM-register':
+  exec { 'RHSM-register':
     command => "subscription-manager register --name='${::fqdn}'${_user}${_password}${_org}${_activationkey}${proxycli}",
     onlyif  => 'subscription-manager identity 2>&1 | grep "not yet registered"',
     path    => '/bin:/usr/bin:/usr/sbin',
     require => Package['subscription-manager'],
   }
 
-  exec { 'RHNSM-subscribe':
+  exec { 'RHSM-subscribe':
     command => $command,
     onlyif  => 'subscription-manager list 2>&1 | grep "Expired\|Not Subscribed\|Unknown"',
     path    => '/bin:/usr/bin:/usr/sbin',
-    require => Exec['RHNSM-register'],
+    require => Exec['RHSM-register'],
   }
 
   if $repo_extras {
     ::rhsm::repo { "rhel-${::operatingsystemmajrelease}-server-extras-rpms":
-      require => Exec['RHNSM-register'],
+      require => Exec['RHSM-register'],
     }
   }
 
   if $repo_optional {
     ::rhsm::repo { "rhel-${::operatingsystemmajrelease}-server-optional-rpms":
-      require => Exec['RHNSM-register'],
+      require => Exec['RHSM-register'],
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,13 +23,13 @@ describe 'rhsm', type: :class do
         it { is_expected.to contain_file('/etc/rhsm/rhsm.conf') }
         it { is_expected.to contain_exec('sm yum clean all') }
         it do
-          is_expected.to contain_exec('RHNSM-register').with(
+          is_expected.to contain_exec('RHSM-register').with(
             command: "subscription-manager register --name='#{facts[:fqdn]}' --username='username' --password='password'"
           )
         end
 
         it do
-          is_expected.to contain_exec('RHNSM-subscribe').with(
+          is_expected.to contain_exec('RHSM-subscribe').with(
             command: 'subscription-manager attach --auto'
           )
         end
@@ -44,7 +44,7 @@ describe 'rhsm', type: :class do
         end
 
         it do
-          is_expected.to contain_exec('RHNSM-register').with(
+          is_expected.to contain_exec('RHSM-register').with(
             command: "subscription-manager register --name='#{facts[:fqdn]}' --org='org' --activationkey='key'"
           )
         end


### PR DESCRIPTION
Change servername to subscription.rhsm.redhat.com and rename RHNSM to RHSM

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
