### PR TITLE
Update rhsm.conf template (5.15.1) and add configurable params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,9 +13,23 @@
 # @param activationkey [String] Activationkey to use
 # @param servername [String] Servername, default provided
 #   Used directly in rhsm.conf template
+# @param serverprefix [String] server.prefix to use
+#   Used directly in rhsm.conf template
+#   /rhsm for Satellite 6
+#   /subscription for RHSM
+# @param serverport [Integer] server.port to use
+#   Used directly in rhsm.conf template
+# @param repo_ca_cert [String] rhsm.repo_ca_cert
+#   Used directly in rhsm.conf template
+#   %(ca_cert_dir)skatello-server-ca.pem for Satellite 6
+#   %(ca_cert_dir)sredhat-uep.pem for RHSM
+# @param full_refresh_on_yum [Integer] rhsm.full_refresh_on_yum
+#   Used directly in rhsm.conf template
+#   1 for Satellite 6
+#   0 for RHSM
 # @param pool [String] Attach system to a specific pool instead of auto attach to compatible subscriptions
 # @param proxy_hostname [String] Proxy hostname
-# @param proxy_port [String] Proxy port
+# @param proxy_port [Integer] Proxy port
 # @param proxy_user [String] Proxy user
 # @param proxy_password [String] Proxy password
 # @param baseurl [String] Base URL for rhsm, default provided
@@ -35,20 +49,24 @@
 # @author Ger Apeldoorn <info@gerapeldoorn.nl>
 #
 class rhsm (
-  $rh_user        = undef,
-  $rh_password    = undef,
-  $org            = undef,
-  $activationkey  = undef,
-  $servername     = 'subscription.rhsm.redhat.com',
-  $pool           = undef,
-  $proxy_hostname = undef,
-  $proxy_port     = undef,
-  $proxy_user     = undef,
-  $proxy_password = undef,
-  $baseurl        = 'https://cdn.redhat.com',
-  $package_ensure = 'latest',
-  $repo_extras    = false,
-  $repo_optional  = false
+  $rh_user             = undef,
+  $rh_password         = undef,
+  $org                 = undef,
+  $activationkey       = undef,
+  $pool                = undef,
+  $proxy_hostname      = undef,
+  $proxy_port          = undef,
+  $proxy_user          = undef,
+  $proxy_password      = undef,
+  $baseurl             = 'https://cdn.redhat.com',
+  $servername          = 'subscription.rhsm.redhat.com',
+  $serverprefix        = '/subscription',
+  $serverport          = 443,
+  $repo_ca_cert        = '%(ca_cert_dir)sredhat-uep.pem',
+  $full_refresh_on_yum = 0,
+  $package_ensure      = 'latest',
+  $repo_extras         = false,
+  $repo_optional       = false
 ) {
 
   if ($rh_user == undef and $rh_password == undef) and ($org == undef and $activationkey == undef) {

--- a/templates/rhsm.conf.erb
+++ b/templates/rhsm.conf.erb
@@ -6,10 +6,10 @@
 hostname = <%= @servername %>
 
 # Server prefix:
-prefix = /subscription
+prefix = <%= @serverprefix %>
 
 # Server port:
-port = 443
+port = <%= @serverport %>
 
 # Set to 1 to disable certificate validation:
 insecure = 0
@@ -30,6 +30,9 @@ proxy_user = <%= @proxy_user %>
 # password for basic http proxy auth, if needed
 proxy_password = <%= @proxy_password %>
 
+# host/domain suffix blacklist for proxy, if needed
+no_proxy =
+
 [rhsm]
 # Content base URL:
 baseurl= <%= @baseurl %>
@@ -38,7 +41,7 @@ baseurl= <%= @baseurl %>
 ca_cert_dir = /etc/rhsm/ca/
 
 # Default CA cert to use when generating yum repo configs:
-repo_ca_cert = %(ca_cert_dir)sredhat-uep.pem
+repo_ca_cert = <%= @repo_ca_cert %>
 
 # Where the certificates should be stored
 productCertDir = /etc/pki/product
@@ -49,7 +52,7 @@ consumerCertDir = /etc/pki/consumer
 manage_repos = <%= @manage_repos %>
 
 # Refresh repo files with server overrides on every yum command
-full_refresh_on_yum = 0
+full_refresh_on_yum = <%= @full_refresh_on_yum %>
 
 # If set to zero, the client will not report the package profile to
 # the subscription management service.
@@ -66,5 +69,15 @@ pluginConfDir = /etc/rhsm/pluginconf.d
 certCheckInterval = 240
 # Interval to run auto-attach (in minutes):
 autoAttachInterval = 1440
+# If set to zero, the checks done by the rhsmcertd daemon will not be splayed (randomly offset)
+splay = 1
 
+[logging]
+default_log_level = INFO
+# subscription_manager = DEBUG
+# subscription_manager.managercli = DEBUG
+# rhsm = DEBUG
+# rhsm.connection = DEBUG
+# rhsm-app = DEBUG
+# rhsm-app.rhsmd = DEBUG
 


### PR DESCRIPTION
Configurable parameters are needed when using Red Hat Satellite 6 or SAM

This addresses issue #11

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
