### PR TITLE
Add params for adding custom certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,24 @@ Just declare the module with parameters, or load the data from Hiera.
 
 ## Usage
 ```puppet
-  class { 'rhsm':
-   rh_user     => 'myuser',
-   rh_password => 'mypassword',
-  }
+class { 'rhsm':
+  rh_user     => 'myuser',
+  rh_password => 'mypassword',
+}
 ```
 To attach the system to a specific pool (can be found on a registered system with `subscription-manager list --available`):
 
 ```puppet
-  class { 'rhsm':
-   rh_user     => 'myuser',
-   rh_password => 'mypassword',
-   pool        => 'the_pool_id'
-  }
+class { 'rhsm':
+  rh_user     => 'myuser',
+  rh_password => 'mypassword',
+  pool        => 'the_pool_id'
+}
 ```
 
 ### Hiera (recommended)
 ```puppet
-  include rhsm
+include rhsm
 ```
   Hierafile:
 
@@ -40,16 +40,36 @@ rhsm::rh_password: mypassword
 If the RedHat node must use a proxy to access the internet, you'll have to provide at least the hostname and TCP port.
 
 ```puppet
-  class { 'rhsm':
-   proxy_hostname => 'my.proxy.net',
-   proxy_port     => 8080
-   rh_user        => 'myuser',
-   rh_password    => 'mypassword',
-  }
+class { 'rhsm':
+  proxy_hostname => 'my.proxy.net',
+  proxy_port     => 8080
+  rh_user        => 'myuser',
+  rh_password    => 'mypassword',
+}
 ```
 You shouldn't specify the protocol, subscription-manager will use HTTP. For proxies with authentication, specify the `proxy_user` and `proxy_password` values.
 
 The proxy settings will be used to register the system and as connection option for all the YUM repositories generated in `/etc/yum.repos.d/redhat.repo`
+
+### Satellite 6
+Registering with Red Hat Satellite 6 needs some additional settings.
+
+```puppet
+class { 'rhsm':
+  activationkey         => 'act-lce-rhel-7,act-product',
+  org                   => 'satellite_organization',
+  servername            => 'satellite.example.com',
+  serverprefix          => '/rhsm',
+  repo_ca_cert_filename => 'katello-server-ca.pem',
+  repo_ca_cert_source   => 'puppet:///modules/profile/katello-server-ca.crt',
+  full_refresh_on_yum   => 1,
+  baseurl               => 'https://satellite.example.com/pulp/repos',
+}
+```
+
+* You need to specify either (`rh_user` and `rh_password`) or (`org` and `activationkey`).
+* Multiple Activationkeys might be provided, separated by comma.
+* Download the corresponding certificate from your Satellite (<https://satellite.example.com/pub/katelllo-server-ca.crt>) and publish it, e.g. with a (profile) module.
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -135,7 +135,7 @@ class rhsm (
     content => template('rhsm/rhsm.conf.erb'),
   }
 
-  if $repo_ca_cert_source != undef {
+  if $repo_ca_cert_source {
     file { "${ca_cert_dir}/${repo_ca_cert_filename}":
       ensure => present,
       mode   => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,8 +23,6 @@
 # @param repo_ca_cert_filename [String] File containting the CA cert to use when generating yum repo configs
 #   katello-server-ca.pem for Satellite 6
 #   redhat-uep.pem for RHSM
-# @param repo_ca_cert [String] rhsm.repo_ca_cert
-#   Used directly in rhsm.conf template
 # @param repo_ca_cert_source [String] URI, if set the content is used for CA file resource ${ca_cert_dir}/${repo_ca_cert_filename}
 #   Possible values are puppet:, file: and http:
 # @param manage_repos [Integer] 1 if subscription manager should manage yum repos file or
@@ -70,7 +68,6 @@ class rhsm (
   $serverport            = 443,
   $ca_cert_dir           = '/etc/rhsm/ca/',
   $repo_ca_cert_filename = 'redhat-uep.pem',
-  $repo_ca_cert          = "%(ca_cert_dir)s${repo_ca_cert_filename}",
   $repo_ca_cert_source   = undef,
   $manage_repos          = 1,
   $full_refresh_on_yum   = 0,

--- a/templates/rhsm.conf.erb
+++ b/templates/rhsm.conf.erb
@@ -38,7 +38,7 @@ no_proxy =
 baseurl= <%= @baseurl %>
 
 # Server CA certificate location:
-ca_cert_dir = /etc/rhsm/ca/
+ca_cert_dir = <%= @ca_cert_dir %>
 
 # Default CA cert to use when generating yum repo configs:
 repo_ca_cert = <%= @repo_ca_cert %>

--- a/templates/rhsm.conf.erb
+++ b/templates/rhsm.conf.erb
@@ -41,7 +41,7 @@ baseurl= <%= @baseurl %>
 ca_cert_dir = <%= @ca_cert_dir %>
 
 # Default CA cert to use when generating yum repo configs:
-repo_ca_cert = <%= @repo_ca_cert %>
+repo_ca_cert = %(ca_cert_dir)s<%= @repo_ca_cert_filename %>
 
 # Where the certificates should be stored
 productCertDir = /etc/pki/product


### PR DESCRIPTION
When using Red Hat Satellite 6 one needs to change the rhsm certificates.

`README.md` has an example usage with Red Hat Satellite 6.

Closes #11 and #6 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
