### PR TITLE
release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v3.0.0](https://github.com/voxpupuli/puppet-rhsm/tree/v3.0.0) (2017-11-16)
+[Full Changelog](https://github.com/voxpupuli/puppet-rhsm/compare/v2.1.1...v3.0.0)
+
+**Implemented enhancements:**
+
+- Add params for adding custom certificates [\#57](https://github.com/voxpupuli/puppet-rhsm/pull/57) ([kallies](https://github.com/kallies))
+
+**Fixed bugs:**
+
+- Fix yumrepo 'enabled' property [\#59](https://github.com/voxpupuli/puppet-rhsm/pull/59) ([cohdjn](https://github.com/cohdjn))
+
+**Closed issues:**
+
+- repo\_optional always caused puppet run to make change [\#58](https://github.com/voxpupuli/puppet-rhsm/issues/58) ([cohdjn](https://github.com/cohdjn))
+
 ## [v2.1.1](https://github.com/voxpupuli/puppet-rhsm/tree/v2.1.1) (2017-10-10)
 [Full Changelog](https://github.com/voxpupuli/puppet-rhsm/compare/v2.1.0...v2.1.1)
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-rhsm",
-  "version": "2.1.2-rc0",
+  "version": "3.0.0",
   "author": "Vox Pupuli",
   "summary": "Register with the RedHat Subscription Management",
   "license": "Apache-2.0",


### PR DESCRIPTION
#57 is marked as backwards-incompatible. The usage hasn't changed though. Old profiles don't have to be changed, Red Hat Satellite 6 integration wasn't possible before.

If the backwards-incompatible remark should remain, release version has to be 3.0.0