### PR TITLE
Move RHSM-subscribe dependency inside repo type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,9 +159,7 @@ class rhsm (
 
   unless(empty($enabled_repo_ids)) {
     $enabled_repo_ids.each | $repo_id | {
-      rhsm::repo { $repo_id:
-        require => Exec['RHSM-subscribe'],
-      }
+      rhsm::repo { $repo_id: }
     }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,6 +18,7 @@ define rhsm::repo (
       exec { "RHSM-enable_${title}":
         command => "subscription-manager repos --enable ${title}",
         path    => '/bin:/usr/bin:/usr/sbin',
+        require => Exec['RHSM-subscribe'],
       }
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -64,8 +64,8 @@ describe 'rhsm', type: :class do
 
         it { is_expected.to have_rhsm__repo_resource_count(2) }
 
-        it { is_expected.to contain_rhsm__repo('rhel-7-server-rpms').that_requires('Exec[RHSM-subscribe]') }
-        it { is_expected.to contain_rhsm__repo('rhel-7-server-optional-rpms').that_requires('Exec[RHSM-subscribe]') }
+        it { is_expected.to contain_rhsm__repo('rhel-7-server-rpms') }
+        it { is_expected.to contain_rhsm__repo('rhel-7-server-optional-rpms') }
       end
     end
   end

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -10,6 +10,8 @@ describe 'rhsm::repo' do
         )
       end
 
+      let(:pre_condition) { 'class { "::rhsm": rh_password => "password", rh_user => "username" }' }
+
       context 'enabling server rpms' do
         let(:title) { 'rhel-7-server-rpms' }
 
@@ -18,7 +20,7 @@ describe 'rhsm::repo' do
         it {
           is_expected.to contain_exec('RHSM-enable_rhel-7-server-rpms').with(
             command: 'subscription-manager repos --enable rhel-7-server-rpms'
-          )
+          ).that_requires('Exec[RHSM-subscribe]')
         }
       end
 
@@ -30,7 +32,7 @@ describe 'rhsm::repo' do
         it {
           is_expected.to contain_exec('RHSM-enable_rhel-7-optional-rpms').with(
             command: 'subscription-manager repos --enable rhel-7-optional-rpms'
-          )
+          ).that_requires('Exec[RHSM-subscribe]')
         }
       end
 
@@ -49,7 +51,7 @@ describe 'rhsm::repo' do
 
         it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.not_to contain_exec('RHSM-enable_rhel-7-optional-rpms') }
+        it { is_expected.not_to contain_exec('RHSM-enable_rhel-7-optional-rpms').that_requires('Exec[RHSM-subscribe]') }
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
When using the rhsm::repo type outside of this module,
one does not have to worry about requiring `Exec['RHSM-subscribe']`.

#### This Pull Request (PR) fixes the following issues
n/a
