### PR TITLE
Add defaults and make server_timeout and inotify configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,9 @@
 # @param baseurl Base URL for rhsm, default provided
 # @param package_ensure Whether to install subscription-manager, directly passed to the `ensure` param of the package.
 # @param enabled_repo_ids A listing of the Repo IDs to provide to the subscription-manager repo --enable command.
+# @param server_timeout HTTP timeout in seconds
+# @param inotify Inotify is used for monitoring changes in directories with certificates. When this directory is mounted using a network
+#   file system without inotify notification support (e.g. NFS), then disabling inotify is strongly recommended.
 #
 # @example
 #   include rhsm
@@ -70,6 +73,8 @@ class rhsm (
   Integer[0,1]           $full_refresh_on_yum   = 0,
   String[1]              $package_ensure        = 'installed',
   Array[String[1]]       $enabled_repo_ids      = [],
+  Integer[0,1]           $inotify               = 1,
+  Integer[0]             $server_timeout        = 180,
 ){
 
   if ($rh_user == undef and $rh_password == undef) and ($org == undef and $activationkey == undef) {

--- a/templates/rhsm.conf.erb
+++ b/templates/rhsm.conf.erb
@@ -33,9 +33,14 @@ proxy_password = <%= @proxy_password %>
 # host/domain suffix blacklist for proxy, if needed
 no_proxy =
 
+server_timeout = <%= @server_timeout %>
+
 [rhsm]
 # Content base URL:
 baseurl= <%= @baseurl %>
+
+# Repository metadata GPG key URL:
+repomd_gpg_url =
 
 # Server CA certificate location:
 ca_cert_dir = <%= @ca_cert_dir %>
@@ -64,6 +69,17 @@ pluginDir = /usr/share/rhsm-plugins
 # The directory to search for plugin configuration files
 pluginConfDir = /etc/rhsm/pluginconf.d
 
+# Manage automatic enabling of yum/dnf plugins (product-id, subscription-manager)
+auto_enable_yum_plugins = 1
+
+# Inotify is used for monitoring changes in directories with certificates.
+# Currently only the /etc/pki/consumer directory is monitored by the
+# rhsm.service. When this directory is mounted using a network file system
+# without inotify notification support (e.g. NFS), then disabling inotify
+# is strongly recommended. When inotify is disabled, periodical directory
+# polling is used instead.
+inotify = <%= @inotify %>
+
 [rhsmcertd]
 # Interval to run cert check (in minutes):
 certCheckInterval = 240
@@ -80,4 +96,3 @@ default_log_level = INFO
 # rhsm.connection = DEBUG
 # rhsm-app = DEBUG
 # rhsm-app.rhsmd = DEBUG
-


### PR DESCRIPTION
#### Pull Request (PR) description

Add defaults from subscription-manager 1.21.10

Make two of them configurable:

* inotify
* server_timeout

server_timeout is measured per http call, not the overall time of a subscription-manager run. The default of 180s might lead to puppet run issues (`subscription-manager repos --list-enabled` is used in the rhsm fact, this command triggers 7+ http connections).

#### This Pull Request (PR) fixes the following issues

Fixes #85