### PR TITLE
Add types and providers from crayfishx/puppet-rhsm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,32 @@
 
 1. [Description](#description)
 2. [Setup](#setup)
-3. [Usage](#usage)
-4. [Limitations](#limitations)
-5. [Development](#development)
+3. [Types](#types)
+4. [Usage](#usage)
+5. [Limitations](#limitations)
+6. [Development](#development)
 
 ## Description
 
-This module registers your systems with RedHat Subscription Management.
+This module registers your systems with Red Hat Subscription Management.
 
 ## Setup
 
 Just declare the module with parameters, or load the data from Hiera.
 
+## Types
+
+### rh_repo
+
+Manage yum repos via the subscription-manager.
+
+
+### rh_subscription
+
+Enable or disable RH subscriptions based on their pool ID.
+
 ## Usage
+
 ```puppet
 class { 'rhsm':
   rh_user     => 'myuser',
@@ -35,7 +48,24 @@ class { 'rhsm':
 }
 ```
 
+Use `rh_repo` type to add a repository:
+
+```puppet
+rh_repo { 'rhel-7-server-extras-rpms':
+ ensure => present,
+}
+```
+
+Use `rh_subscription` type to add or remove a subscription based on its pool ID:
+
+```puppet
+rh_subscription { '8e8e7f7a77554a776277ac6dca654':
+  ensure => present,
+}
+```
+
 ### Hiera (recommended)
+
 ```puppet
 include rhsm
 ```

--- a/lib/puppet/provider/rh_repo/redhat.rb
+++ b/lib/puppet/provider/rh_repo/redhat.rb
@@ -1,0 +1,49 @@
+# @author Craig Dunn crayfishx/puppet-rhsm
+Puppet::Type.type(:rh_repo).provide(:redhat) do
+  commands rhsm: '/sbin/subscription-manager'
+  mk_resource_methods
+
+  def self.repos
+    repos = {}
+    rhsm('repos', '--list').split("\n\n").each do |blk|
+      repo_data = {}
+      blk.split("\n").each do |line|
+        element = line.split(%r{:})
+        repo_data[element.shift] = element.join.lstrip
+      end
+      repos[repo_data['Repo ID']] = {
+        enabled: repo_data['Enabled']
+      }
+    end
+    repos
+  end
+
+  def self.instances
+    repos.map do |rid, data|
+      new(
+        ensure: data[:enabled] == '0' ? :disabled : :enabled,
+        name:   rid
+      )
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :enabled
+  end
+
+  def create
+    rhsm('repos', "--enable=#{@resource[:name]}")
+  end
+
+  def destroy
+    rhsm('repos', "--disable=#{@resource[:name]}")
+  end
+end

--- a/lib/puppet/provider/rh_repo/redhat.rb
+++ b/lib/puppet/provider/rh_repo/redhat.rb
@@ -1,6 +1,6 @@
 # @author Craig Dunn crayfishx/puppet-rhsm
 Puppet::Type.type(:rh_repo).provide(:redhat) do
-  commands rhsm: '/sbin/subscription-manager'
+  commands rhsm: '/usr/sbin/subscription-manager'
   mk_resource_methods
 
   def self.repos

--- a/lib/puppet/provider/rh_subscription/redhat.rb
+++ b/lib/puppet/provider/rh_subscription/redhat.rb
@@ -1,6 +1,6 @@
 # @author Craig Dunn crayfishx/puppet-rhsm
 Puppet::Type.type(:rh_subscription).provide(:redhat) do
-  commands rhsm: '/sbin/subscription-manager'
+  commands rhsm: '/usr/sbin/subscription-manager'
   mk_resource_methods
 
   def self.subscriptions

--- a/lib/puppet/provider/rh_subscription/redhat.rb
+++ b/lib/puppet/provider/rh_subscription/redhat.rb
@@ -1,0 +1,63 @@
+# @author Craig Dunn crayfishx/puppet-rhsm
+Puppet::Type.type(:rh_subscription).provide(:redhat) do
+  commands rhsm: '/sbin/subscription-manager'
+  mk_resource_methods
+
+  def self.subscriptions
+    subs = {}
+    rhsm('list', '--consumed').split("\n\n").each do |blk|
+      sub_data = {}
+      blk.split("\n").each do |line|
+        element = line.match(%r{^([^:]+):[^\w]+(\w.*)})
+        next unless element.is_a?(MatchData)
+        sub_data[element[1]] = element[2]
+      end
+      subs[sub_data['Pool ID']] = {
+        name: sub_data['Subscription Name'],
+        active: sub_data['Active'],
+        serial: sub_data['Serial']
+      }
+    end
+    subs
+  end
+
+  def self.active?(str)
+    case str
+    when 'True'
+      :true
+    when 'False'
+      :false
+    end
+  end
+
+  def self.instances
+    subscriptions.map do |pool, data|
+      new(
+        ensure: :present,
+        name:   pool,
+        active: active?(data[:active]),
+        serial: data[:serial]
+      )
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    rhsm('attach', "--pool=#{@resource[:name]}")
+  end
+
+  def destroy
+    rhsm('remove', "--serial=#{@property_hash[:serial]}")
+  end
+end

--- a/lib/puppet/type/rh_repo.rb
+++ b/lib/puppet/type/rh_repo.rb
@@ -1,0 +1,21 @@
+# @author Craig Dunn crayfishx/puppet-rhsm
+Puppet::Type.newtype(:rh_repo) do
+  @doc = 'Manage Red Hat subscriptions'
+
+  ensurable do
+    newvalue(:present) do
+      provider.create unless provider.exists?
+    end
+
+    aliasvalue(:enabled, :present)
+
+    newvalue(:absent) do
+      provider.destroy if provider.exists?
+    end
+    aliasvalue(:disabled, :absent)
+  end
+
+  newparam(:name) do
+    isnamevar
+  end
+end

--- a/lib/puppet/type/rh_subscription.rb
+++ b/lib/puppet/type/rh_subscription.rb
@@ -1,0 +1,16 @@
+# @author Craig Dunn crayfishx/puppet-rhsm
+Puppet::Type.newtype(:rh_subscription) do
+  @doc = 'Manage Red Hat subscriptions'
+
+  ensurable
+
+  newparam(:name, isnamevar: true) do
+  end
+
+  newproperty(:active) do
+    newvalues(:true, :false)
+  end
+
+  newparam(:serial) do
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR introduces types and providers used in @crayfishx 's puppet-rhsm.

This is useful if you need to enable additional subscriptions (products on Satellite 6) through Puppet (not only by the use of an activation key or multiple activation keys).

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #87 