### PR TITLE
fix: use sensitive() for rspec-puppet 2.8

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -28,7 +28,7 @@ describe 'rhsm', type: :class do
         end
         it do
           is_expected.to contain_exec('RHSM-register').with(
-            command: "subscription-manager register --name='#{facts[:fqdn]}' --username='username' --password='password'"
+            command: sensitive("subscription-manager register --name='#{facts[:fqdn]}' --username='username' --password='password'")
           )
         end
       end
@@ -43,7 +43,7 @@ describe 'rhsm', type: :class do
 
         it do
           is_expected.to contain_exec('RHSM-register').with(
-            command: "subscription-manager register --name='#{facts[:fqdn]}' --org='org' --activationkey='key'"
+            command: sensitive("subscription-manager register --name='#{facts[:fqdn]}' --org='org' --activationkey='key'")
           )
         end
       end


### PR DESCRIPTION
This fixes unit tests for rspec-puppet 2.8.