### PR TITLE
add no_proxy to rhsm.conf, defaults to undef

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ class { 'rhsm':
 }
 ```
 If you don't specify the protocol, subscription-manager will use HTTP. If you want to connect via HTTPS, set the `proxy_scheme` to `https`. For proxies with authentication, specify the `proxy_user` and `proxy_password` values.
+Depending on your environment, you also migh need to set the `no_proxy` value.
 
 The proxy settings will be used to register the system and as connection option for all the YUM repositories generated in `/etc/yum.repos.d/redhat.repo`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -60,6 +60,7 @@ The following parameters are available in the `rhsm` class:
 * [`proxy_scheme`](#proxy_scheme)
 * [`proxy_port`](#proxy_port)
 * [`proxy_user`](#proxy_user)
+* [`no_proxy`](#no_Proxy)
 * [`proxy_password`](#proxy_password)
 * [`baseurl`](#baseurl)
 * [`package_ensure`](#package_ensure)
@@ -214,6 +215,14 @@ Default value: ``undef``
 Data type: `Optional[String[1]]`
 
 Proxy password
+
+Default value: ``undef``
+
+##### <a name="no_proxy"></a>`no_proxy`
+
+Data type: `Optional[String[1]]`
+
+no_proxy definition
 
 Default value: ``undef``
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@
 # @param proxy_port Proxy port
 # @param proxy_user Proxy user
 # @param proxy_password Proxy password
+# @param no_proxy no_proxy definition
 # @param baseurl Base URL for rhsm, default provided
 # @param package_ensure Whether to install subscription-manager, directly passed to the `ensure` param of the package.
 # @param enabled_repo_ids A listing of the Repo IDs to provide to the subscription-manager repo --enable command.
@@ -66,6 +67,7 @@ class rhsm (
   Optional[Stdlib::Port] $proxy_port            = undef,
   Optional[String[1]]    $proxy_user            = undef,
   Optional[String[1]]    $proxy_password        = undef,
+  Optional[String[1]]    $no_proxy              = undef,
   Stdlib::Httpurl        $baseurl               = 'https://cdn.redhat.com',
   Stdlib::Fqdn           $servername            = 'subscription.rhsm.redhat.com',
   Stdlib::Absolutepath   $serverprefix          = '/subscription',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -92,7 +92,7 @@ describe 'rhsm', type: :class do
         let(:params) do
           {
             org: 'org',
-            activationkey: 'key,'
+            activationkey: 'key',
             no_proxy: 'proxy.local'
           }
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -91,6 +91,8 @@ describe 'rhsm', type: :class do
       context 'with no_proxy set to proxy.local' do
         let(:params) do
           {
+            org: 'org',
+            activationkey: 'key,'
             no_proxy: 'proxy.local'
           }
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -87,6 +87,18 @@ describe 'rhsm', type: :class do
           is_expected.to contain_file('/etc/rhsm/rhsm.conf').with_content(%r{^proxy_scheme = https$})
         end
       end
+
+      context 'with no_proxy set to proxy.local' do
+        let(:params) do
+          {
+            no_proxy: 'proxy.local'
+          }
+        end
+
+        it do
+          is_expected.to contain_file('/etc/rhsm/rhsm.conf').with_content(%r{^no_proxy = proxy.local$})
+        end
+      end
     end
   end
 end

--- a/templates/rhsm.conf.erb
+++ b/templates/rhsm.conf.erb
@@ -34,7 +34,7 @@ proxy_user = <%= @proxy_user %>
 proxy_password = <%= @proxy_password %>
 
 # host/domain suffix blacklist for proxy, if needed
-no_proxy =
+no_proxy = <%= @no_proxy %>
 
 server_timeout = <%= @server_timeout %>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Our architecture needs the no_proxy statement to be configurable.
This simply adds the value to the template.
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
