### PR TITLE
Fix subscription-manager credential logic

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@ class rhsm (
   Integer[0]             $server_timeout        = 180,
   Integer[0]             $process_timeout       = 300,
 ) {
-  if ($rh_user == undef and $rh_password == undef) and ($org == undef and $activationkey == undef) {
+  if ($rh_user == undef and $rh_password == undef) or ($org == undef and $activationkey == undef) {
     fail("${module_name}: Must provide rh_user and rh_password or org and activationkey")
   }
 


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Must provider username and password _or_ organization and activationkey
Supplying both does not make sense

#### This Pull Request (PR) fixes the following issues
n/a

