### PR TITLE
Ensure dnf/yum plugin config has read.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,6 +142,10 @@ class rhsm (
     }
 
     file { $plugin_path:
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
       content => epp("${module_name}/ini.conf.epp", { 'stanzas' => $plugin_settings }),
       require => Package['subscription-manager'],
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -39,12 +39,18 @@ describe 'rhsm', type: :class do
         if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] < '8'
           it do
             is_expected.to contain_file('/etc/yum/pluginconf.d/subscription-manager.conf').
+              with_owner('root').
+              with_group('root').
+              with_mode('0644').
               with_content(%r{^\[main\]$}).
               with_content(%r{^enabled=1$})
           end
         else
           it do
             is_expected.to contain_file('/etc/dnf/plugins/subscription-manager.conf').
+              with_owner('root').
+              with_group('root').
+              with_mode('0644').
               with_content(%r{^\[main\]$}).
               with_content(%r{^enabled=1$})
           end
@@ -133,6 +139,9 @@ describe 'rhsm', type: :class do
           # disable_system_repos doesn't actually do anything on EL6 or 7
           it do
             is_expected.to contain_file('/etc/yum/pluginconf.d/subscription-manager.conf').
+              with_owner('root').
+              with_group('root').
+              with_mode('0644').
               with_content(%r{^\[main\]$}).
               with_content(%r{^enabled=0$}).
               with_content(%r{^disable_system_repos=1$})
@@ -140,6 +149,9 @@ describe 'rhsm', type: :class do
         else
           it do
             is_expected.to contain_file('/etc/dnf/plugins/subscription-manager.conf').
+              with_owner('root').
+              with_group('root').
+              with_mode('0644').
               with_content(%r{^\[main\]$}).
               with_content(%r{^enabled=0$}).
               with_content(%r{^disable_system_repos=1$})


### PR DESCRIPTION
This is mostly a sanity check, but, if you've set `file` to have
a default `mode` without world read, you'll get an error from
yum/dnf about this.