### PR TITLE
When purging unmanaged repos, this file needs to be known to puppet.

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,6 +23,7 @@ describe 'rhsm', type: :class do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_package('subscription-manager') }
         it { is_expected.to contain_file('/etc/rhsm/rhsm.conf') }
+        it { is_expected.to contain_file('/etc/yum.repos.d/redhat.repo') }
 
         it do
           is_expected.to contain_service('rhsmcertd').with(


### PR DESCRIPTION
#### Pull Request (PR) description
If you set /etc/yum.repos.d/ to `purge => true` it is helpful if puppet knows to leave redhat.repo alone.

#### This Pull Request (PR) fixes the following issues
N/A