### PR TITLE
Don't manage redhat.repo directly.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,10 +143,6 @@ class rhsm (
     file { $repo_filename:
       ensure => 'absent',
     }
-  } else {
-    file { $repo_filename:
-      ensure => 'file',
-    }
   }
 
   unless empty($plugin_settings) {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,7 +23,7 @@ describe 'rhsm', type: :class do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_package('subscription-manager') }
         it { is_expected.to contain_file('/etc/rhsm/rhsm.conf') }
-        it { is_expected.to contain_file('/etc/yum.repos.d/redhat.repo') }
+        it { is_expected.not_to contain_file('/etc/yum.repos.d/redhat.repo') }
         it { is_expected.to contain_file('/etc/rhsm/rhsm.conf').with_content(%r{^package_profile_on_trans = 0$}) }
 
         it do


### PR DESCRIPTION
#### Pull Request (PR) description

A number of folks have a dependency ordering on rhsm such that
the rhsm class is before the yum class.  This creates an ordering
problem similar to:

Error: Found 1 dependency cycle:
(File[/etc/yum.repos.d/redhat.repo] => Class[Rhsm] => Class[Yum] => File[/etc/yum.repos.d] => File[/etc/yum.repos.d/redhat.repo])