### PR TITLE
Add a switch to prevent caring about redhat.repo if needed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,8 @@
 #   file system without inotify notification support (e.g. NFS), then disabling inotify is strongly recommended.
 # @param process_timeout
 #   The time in seconds we will allow the rhsmd cron job to run before terminating the process.
+# @param manage_repo_filename
+#   Should puppet try to manage the repo file subscription-manager uses?
 # @param repo_filename
 #   The name of the repo file subscription-manager uses.
 # @param plugin_settings
@@ -87,6 +89,7 @@ class rhsm (
   Integer[0,1]           $inotify                  = 1,
   Integer[0]             $server_timeout           = 180,
   Integer[0]             $process_timeout          = 300,
+  Boolean                $manage_repo_filename     = true,
   Stdlib::Absolutepath   $repo_filename            = '/etc/yum.repos.d/redhat.repo',
   Hash                   $plugin_settings          = { 'main' => { 'enabled' => 1 } },
   Integer[0,1]           $package_profile_on_trans = 0,
@@ -139,13 +142,15 @@ class rhsm (
     notify  => Service['rhsmcertd'],
   }
 
-  if $package_ensure == 'absent' {
-    file { $repo_filename:
-      ensure => 'absent',
-    }
-  } else {
-    file { $repo_filename:
-      ensure => 'file',
+  if $manage_repo_filename {
+    if $package_ensure == 'absent' {
+      file { $repo_filename:
+        ensure => 'absent',
+      }
+    } else {
+      file { $repo_filename:
+        ensure => 'file',
+      }
     }
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -128,13 +128,18 @@ describe 'rhsm', type: :class do
         end
       end
 
-      context 'with specific plugin options' do
+      context 'with specific plugin options and no repo file' do
         let :params do
           {
             rh_password: 'password',
             rh_user: 'username',
+            manage_repo_filename: false,
             plugin_settings: { 'main' => { 'enabled' => 0, 'disable_system_repos' => 1 } }
           }
+        end
+
+        it do
+          is_expected.not_to contain_file('/etc/yum.repos.d/redhat.repo')
         end
 
         if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] < '8'


### PR DESCRIPTION
#### Pull Request (PR) description
In part this was added as a way to mirror the behavior added to the yum module.  Folks who don't want to track yum repos in this manner can avoid the resource declaration.