### PR TITLE
Allow subscriptions to be attached via hiera

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -64,6 +64,7 @@ The following parameters are available in the `rhsm` class:
 * [`no_proxy`](#-rhsm--no_proxy)
 * [`baseurl`](#-rhsm--baseurl)
 * [`package_ensure`](#-rhsm--package_ensure)
+* [`enabled_subscription_ids`](#-rhsm--enabled_subscription_ids)
 * [`enabled_repo_ids`](#-rhsm--enabled_repo_ids)
 * [`server_timeout`](#-rhsm--server_timeout)
 * [`inotify`](#-rhsm--inotify)
@@ -245,6 +246,14 @@ Data type: `String[1]`
 Whether to install subscription-manager, directly passed to the `ensure` param of the package.
 
 Default value: `'installed'`
+
+##### <a name="-rhsm--enabled_subscription_ids"></a>`enabled_subscription_ids`
+
+Data type: `Array[String[1]]`
+
+A listing of subscription IDs to provide to the subscription-manager attach --pool command.
+
+Default value: `[]`
 
 ##### <a name="-rhsm--enabled_repo_ids"></a>`enabled_repo_ids`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@
 # @param no_proxy no_proxy definition
 # @param baseurl Base URL for rhsm, default provided
 # @param package_ensure Whether to install subscription-manager, directly passed to the `ensure` param of the package.
+# @param enabled_subscription_ids A listing of subscription IDs to provide to the subscription-manager attach --pool command.
 # @param enabled_repo_ids A listing of the Repo IDs to provide to the subscription-manager repo --enable command.
 # @param server_timeout HTTP timeout in seconds
 # @param inotify Inotify is used for monitoring changes in directories with certificates. When this directory is mounted using a network
@@ -85,6 +86,7 @@ class rhsm (
   Integer[0,1]           $manage_repos             = 1,
   Integer[0,1]           $full_refresh_on_yum      = 0,
   String[1]              $package_ensure           = 'installed',
+  Array[String[1]]       $enabled_subscription_ids = [],
   Array[String[1]]       $enabled_repo_ids         = [],
   Integer[0,1]           $inotify                  = 1,
   Integer[0]             $server_timeout           = 180,
@@ -178,6 +180,10 @@ class rhsm (
       require => Package['subscription-manager'],
       before  => File['/etc/rhsm/rhsm.conf'],
     }
+  }
+
+  rh_subscription { $enabled_subscription_ids:
+    ensure => present,
   }
 
   rh_repo { $enabled_repo_ids:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -92,6 +92,24 @@ describe 'rhsm', type: :class do
         it { is_expected.to contain_rh_repo('rhel-7-server-optional-rpms') }
       end
 
+      context 'with list of subscriptions to enable' do
+        let(:params) do
+          {
+            rh_password: 'password',
+            rh_user: 'username',
+            enabled_subscription_ids: %w[
+              001234567890
+              00123456789a
+            ]
+          }
+        end
+
+        it { is_expected.to have_rh_subscription_resource_count(2) }
+
+        it { is_expected.to contain_rh_subscription('001234567890') }
+        it { is_expected.to contain_rh_subscription('00123456789a') }
+      end
+
       context 'with proxy scheme set to https' do
         let(:params) do
           {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a parameter to the `rhsm` class to define subscription IDs via hiera. This fixes an observed issue in our environment where some repositories require subscriptions which were not attached at registration time. This allows adding them programmatically via hiera, same as is currently possible for repositories.

I added test cases for the new parameter, and added the parameter to the reference documentation as well. Let me know if anything more is needed.

#### This Pull Request (PR) fixes the following issues
N/A
