### PR TITLE
fix for possible wierd path issues executing subscription-manager

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -215,9 +215,9 @@ class rhsm (
       'activationkey' => $_activationkey,
       'proxycli' => $proxycli,
     }
-    $_reg_command = Sensitive(Deferred('inline_epp', ['subscription-manager register --name="<%= $name %>"<%= $user %><%= $password %><%= $org %><%= $activationkey %><%= $proxycli %>', $variables]))
+    $_reg_command = Sensitive(Deferred('inline_epp', ['/sbin/subscription-manager register --name="<%= $name %>"<%= $user %><%= $password %><%= $org %><%= $activationkey %><%= $proxycli %>', $variables]))
   } else {
-    $_reg_command = Sensitive("subscription-manager register --name='${facts['networking']['fqdn']}'${_user}${_password}${_org}${_activationkey}${proxycli}")
+    $_reg_command = Sensitive("/sbin/subscription-manager register --name='${facts['networking']['fqdn']}'${_user}${_password}${_org}${_activationkey}${proxycli}")
   }
   exec { 'RHSM-register':
     command => $_reg_command,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -34,7 +34,7 @@ describe 'rhsm', type: :class do
 
         it do
           is_expected.to contain_exec('RHSM-register').with(
-            command: sensitive("subscription-manager register --name='#{facts[:fqdn]}' --username='username' --password='password'")
+            command: sensitive("/sbin/subscription-manager register --name='#{facts[:fqdn]}' --username='username' --password='password'")
           )
         end
 
@@ -69,7 +69,7 @@ describe 'rhsm', type: :class do
 
         it do
           is_expected.to contain_exec('RHSM-register').with(
-            command: sensitive("subscription-manager register --name='#{facts[:fqdn]}' --org='org' --activationkey='key'")
+            command: sensitive("/sbin/subscription-manager register --name='#{facts[:fqdn]}' --org='org' --activationkey='key'")
           )
         end
       end
@@ -123,7 +123,7 @@ describe 'rhsm', type: :class do
 
         it do
           is_expected.to contain_exec('RHSM-register').with(
-            command: sensitive("subscription-manager register --name='#{facts[:fqdn]}' --org='org' --activationkey='key' --proxy=https://proxy.example.com:443")
+            command: sensitive("/sbin/subscription-manager register --name='#{facts[:fqdn]}' --org='org' --activationkey='key' --proxy=https://proxy.example.com:443")
           )
         end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

RHEL has a consolehelper based wrapper around subscription-manager at /bin/subscription-manager used for elevating permissions gracefully and interactively - something not available within a puppet run

The real subscription-manager binary is available at /sbin/subscription manager (or more correctly perhaps - /usr/sbin/subscription-manager

for some reason or another likely path ordering when running from within puppet the subscription-manager exec can fail with no output

when disabling the "Sensitive" around the exec you would get this error:

```
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns: Traceback (most recent call last):
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:   File "/bin/subscription-manager", line 9, in <module>
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:     load_entry_point('subscription-manager==1.24.51', 'console_scripts', 'subscription-manager')()
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 378, in load_entry_point
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:     return get_distribution(dist).load_entry_point(group, name)
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2565, in load_entry_point
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:     raise ImportError("Entry point %r not found" % ((group,name),))
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns: ImportError: Entry point ('console_scripts', 'subscription-manager') not found
```

which notes the use of /bin/subscription-manager - this PR explicitly sets the exec to use /sbin/subscription-manager for more reliability

#### This Pull Request (PR) fixes the following issues
none raised (yet)