### PR TITLE
updating path to prefer /sbin

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -222,7 +222,7 @@ class rhsm (
   exec { 'RHSM-register':
     command => $_reg_command,
     creates => '/etc/pki/consumer/cert.pem',
-    path    => '/bin:/usr/bin:/usr/sbin',
+    path    => '/sbin:/usr/sbin:/bin:/usr/bin',
     require => File['/etc/rhsm/rhsm.conf'],
   }
   -> Rh_subscription <||>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

RHEL has a consolehelper based wrapper around subscription-manager at /bin/subscription-manager used for elevating permissions gracefully and interactively - something not available within a puppet run

The real subscription-manager binary is available at /sbin/subscription manager (or more correctly perhaps - /usr/sbin/subscription-manager

for some reason or another likely path ordering when running from within puppet the subscription-manager exec can fail with no output

when disabling the "Sensitive" around the exec you would get this error:

```
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns: Traceback (most recent call last):
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:   File "/bin/subscription-manager", line 9, in <module>
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:     load_entry_point('subscription-manager==1.24.51', 'console_scripts', 'subscription-manager')()
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 378, in load_entry_point
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:     return get_distribution(dist).load_entry_point(group, name)
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:   File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 2565, in load_entry_point
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns:     raise ImportError("Entry point %r not found" % ((group,name),))
Notice: /Stage[main]/Rhsm/Exec[RHSM-register]/returns: ImportError: Entry point ('console_scripts', 'subscription-manager') not found
```

which notes the use of /bin/subscription-manager - this PR explicitly sets the exec to use /sbin/subscription-manager for more reliability

#### This Pull Request (PR) fixes the following issues
none raised (yet)